### PR TITLE
MUP-17325 Fix json4s compatibility issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.idea

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prints
 
-[![Build Status](https://travis-ci.org/softprops/prints.svg)](https://travis-ci.org/softprops/prints)
+[![Build Status](https://travis-ci.org/meetup/prints.svg?branch=master)](https://travis-ci.org/meetup/prints)
 
 a [jwt](https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32) finger printer
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "me.lessis"
 
 name := "prints"
 
-version := "0.1.0"
+version := "0.1.2"
 
 description :=  "jwt interface for scala"
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ resolvers += "softprops-maven" at "http://dl.bintray.com/content/softprops/maven
 
 libraryDependencies ++= Seq(
   "me.lessis" %% "base64" % "0.2.0",
-  "org.json4s" %% "json4s-native" % "3.2.11",
+  "org.json4s" %% "json4s-native" % "3.5.3",
   "org.scalatest" %% "scalatest" % "2.2.1" % "test"
 )
 


### PR DESCRIPTION
`prints` library currently uses `json4s` library of version 3.2.11 which has backward incompatible changes with other versions of the library. This results in compatibility issues when using `prints` in projects depending on different `json4s` version. An example of such issue can be seen [here](https://github.com/json4s/json4s/issues/433).

The PR updates `json4s` dependency in `prints` to the latest stable version (at the moment of writing it's 3.5.3).